### PR TITLE
svg::refactor

### DIFF
--- a/svg/circle.go
+++ b/svg/circle.go
@@ -5,19 +5,19 @@ import (
 	"github.com/jordan-bonecutter/purplecrayon/core"
 )
 
-type svgCircle struct {
-	svgObject
+type circle struct {
+	object
 }
 
-func makeSvgCircle(svg *svg) svgCircle {
-	return svgCircle{makeSvgObject(svg, "circle")}
+func makeCircle(svg *svg) circle {
+	return circle{makeObject(svg, "circle")}
 }
 
-func (s svgCircle) Center(p core.Point) {
+func (s circle) Center(p core.Point) {
 	s.Set("cx", fmt.Sprintf("%f", p.X))
 	s.Set("cy", fmt.Sprintf("%f", p.Y))
 }
 
-func (s svgCircle) Radius(r float64) {
+func (s circle) Radius(r float64) {
 	s.Set("r", fmt.Sprintf("%f", r))
 }

--- a/svg/cursor.go
+++ b/svg/cursor.go
@@ -6,46 +6,46 @@ import (
 	"strings"
 )
 
-type svgCursor struct {
+type cursor struct {
 	moves []string
-	svgObject
+	object
 }
 
-func makeSvgCursor(svg *svg) *svgCursor {
-	return &svgCursor{
-		svgObject: makeSvgObject(svg, "path"),
+func makeCursor(svg *svg) *cursor {
+	return &cursor{
+		object: makeObject(svg, "path"),
 	}
 }
 
-func (s *svgCursor) MoveTo(p core.Point) {
-	s.moves = append(s.moves, fmt.Sprintf("M %f %f", p.X, p.Y))
+func (c *cursor) MoveTo(p core.Point) {
+	c.moves = append(c.moves, fmt.Sprintf("M %f %f", p.X, p.Y))
 }
 
-func (s *svgCursor) MoveToRel(p core.Point) {
-	s.moves = append(s.moves, fmt.Sprintf("m %f %f", p.X, p.Y))
+func (c *cursor) MoveToRel(p core.Point) {
+	c.moves = append(c.moves, fmt.Sprintf("m %f %f", p.X, p.Y))
 }
 
-func (s *svgCursor) LineTo(p core.Point) {
-	s.moves = append(s.moves, fmt.Sprintf("L %f %f", p.X, p.Y))
+func (c *cursor) LineTo(p core.Point) {
+	c.moves = append(c.moves, fmt.Sprintf("L %f %f", p.X, p.Y))
 }
 
-func (s *svgCursor) LineToRel(p core.Point) {
-	s.moves = append(s.moves, fmt.Sprintf("l %f %f", p.X, p.Y))
+func (c *cursor) LineToRel(p core.Point) {
+	c.moves = append(c.moves, fmt.Sprintf("l %f %f", p.X, p.Y))
 }
 
-func (s *svgCursor) QuadTo(p0, p1 core.Point) {
-	s.moves = append(s.moves, fmt.Sprintf("Q %f %f %f %f", p0.X, p0.Y, p1.X, p1.Y))
+func (c *cursor) QuadTo(p0, p1 core.Point) {
+	c.moves = append(c.moves, fmt.Sprintf("Q %f %f %f %f", p0.X, p0.Y, p1.X, p1.Y))
 }
 
-func (s *svgCursor) QuadToRel(p0, p1 core.Point) {
-	s.moves = append(s.moves, fmt.Sprintf("q %f %f %f %f", p0.X, p0.Y, p1.X, p1.Y))
+func (c *cursor) QuadToRel(p0, p1 core.Point) {
+	c.moves = append(c.moves, fmt.Sprintf("q %f %f %f %f", p0.X, p0.Y, p1.X, p1.Y))
 }
 
-func (s *svgCursor) Zip() {
-	s.moves = append(s.moves, "z")
+func (c *cursor) Zip() {
+	c.moves = append(c.moves, "z")
 }
 
-func (s *svgCursor) Close() core.Reference {
-	s.Set("d", strings.Join(s.moves, " "))
-	return s.svgObject.Close()
+func (c *cursor) Close() core.Reference {
+	c.Set("d", strings.Join(c.moves, " "))
+	return c.Close()
 }

--- a/svg/cursor.go
+++ b/svg/cursor.go
@@ -47,5 +47,5 @@ func (c *cursor) Zip() {
 
 func (c *cursor) Close() core.Reference {
 	c.Set("d", strings.Join(c.moves, " "))
-	return c.Close()
+	return c.object.Close()
 }

--- a/svg/linearGradient.go
+++ b/svg/linearGradient.go
@@ -5,45 +5,45 @@ import (
 	"github.com/jordan-bonecutter/purplecrayon/core"
 )
 
-type svgLinearGradient struct {
+type linearGradient struct {
 	svg   *svg
-	stops []svgObject
-	svgObject
+	stops []object
+	object
 }
 
-func makeSvgLinearGradient(svg *svg) *svgLinearGradient {
-	return &svgLinearGradient{
+func makeLinearGradient(svg *svg) *linearGradient {
+	return &linearGradient{
 		svg:       svg,
-		svgObject: makeSvgObject(svg, "linearGradient"),
+		object: makeObject(svg, "linearGradient"),
 	}
 }
 
-func (g *svgLinearGradient) SetLine(p0, p1 core.Point) {
+func (g *linearGradient) SetLine(p0, p1 core.Point) {
 	g.Set("x1", fmt.Sprintf("%f", p0.X))
 	g.Set("y1", fmt.Sprintf("%f", p0.Y))
 	g.Set("x2", fmt.Sprintf("%f", p1.X))
 	g.Set("y2", fmt.Sprintf("%f", p1.Y))
 }
 
-func (g *svgLinearGradient) AddStop(position float64, data string) {
-	stop := makeSvgObject(g.svg, "stop")
+func (g *linearGradient) AddStop(position float64, data string) {
+	stop := makeObject(g.svg, "stop")
 	stop.Set("offset", fmt.Sprintf("%f%%", 100*position))
 	stop.Set("stop-color", data)
 	g.stops = append(g.stops, stop)
 }
 
-func (g *svgLinearGradient) AddRGBStop(position float64, color core.RGB) {
+func (g *linearGradient) AddRGBStop(position float64, color core.RGB) {
 	g.AddStop(position, svgRGB(color))
 }
 
-func (g *svgLinearGradient) AddRGBAStop(position float64, color core.RGBA) {
+func (g *linearGradient) AddRGBAStop(position float64, color core.RGBA) {
 	g.AddStop(position, svgRGBA(color))
 }
 
-func (g *svgLinearGradient) Close() core.Reference {
+func (g *linearGradient) Close() core.Reference {
 	closers := make([]Closer, len(g.stops))
 	for idx, stop := range g.stops {
 		closers[idx] = stop
 	}
-	return g.svgObject.CloseChildren(closers...)
+	return g.CloseChildren(closers...)
 }

--- a/svg/linearGradient.go
+++ b/svg/linearGradient.go
@@ -13,7 +13,7 @@ type linearGradient struct {
 
 func makeLinearGradient(svg *svg) *linearGradient {
 	return &linearGradient{
-		svg:       svg,
+		svg:    svg,
 		object: makeObject(svg, "linearGradient"),
 	}
 }

--- a/svg/object.go
+++ b/svg/object.go
@@ -9,54 +9,54 @@ type Closer interface {
 	Close() core.Reference
 }
 
-type svgObject struct {
+type object struct {
 	*svg
 	name  string
 	attrs map[string]string
 	ref   core.Reference
-	svgPaintable
-	svgTransformable
+	paintable
+	transformable
 }
 
-func makeSvgObject(svg *svg, name string) svgObject {
-	return svgObject{
+func makeObject(svg *svg, name string) object {
+	return object{
 		svg:              svg,
 		name:             name,
 		ref:              svg.nextReference(),
 		attrs:            make(map[string]string),
-		svgPaintable:     makeSvgPaintable(),
-		svgTransformable: makeSvgTransformable(),
+		paintable:     makePaintable(),
+		transformable: makeTransformable(),
 	}
 }
 
-func (o svgObject) Set(k, v string) {
+func (o object) Set(k, v string) {
 	o.attrs[k] = v
 }
 
-func (o svgObject) Open() {
+func (o object) Open() {
 	o.WriteString("\n<")
 	o.writeOpeningTagBody()
 	o.WriteString(">")
 }
 
-func (o svgObject) writeOpeningTagBody() core.Reference {
+func (o object) writeOpeningTagBody() core.Reference {
 	o.WriteString(fmt.Sprintf(`%s id="%s"`, o.name, string(o.ref)))
 	sortedMapIter(o.attrs, func(k, v string) {
 		o.svg.WriteString(fmt.Sprintf(` %s="%s"`, k, v))
 	})
 
-	for _, compiled := range o.svgPaintable.compile() {
+	for _, compiled := range o.paintable.compile() {
 		o.WriteString(" " + compiled)
 	}
 
-	for _, compiled := range o.svgTransformable.compile() {
+	for _, compiled := range o.transformable.compile() {
 		o.WriteString(" " + compiled)
 	}
 
 	return o.ref
 }
 
-func (o svgObject) CloseChildren(children ...Closer) core.Reference {
+func (o object) CloseChildren(children ...Closer) core.Reference {
 	o.Open()
 
 	for _, child := range children {
@@ -66,7 +66,7 @@ func (o svgObject) CloseChildren(children ...Closer) core.Reference {
 	return o.ClosingTag()
 }
 
-func (o svgObject) Close() core.Reference {
+func (o object) Close() core.Reference {
 	o.svg.WriteString("\n<")
 	o.writeOpeningTagBody()
 	o.WriteString(`/>`)
@@ -74,7 +74,7 @@ func (o svgObject) Close() core.Reference {
 	return o.ref
 }
 
-func (o svgObject) ClosingTag() core.Reference {
+func (o object) ClosingTag() core.Reference {
 	o.WriteString(fmt.Sprintf("\n</%s>", o.name))
 	return o.ref
 }

--- a/svg/object.go
+++ b/svg/object.go
@@ -20,10 +20,10 @@ type object struct {
 
 func makeObject(svg *svg, name string) object {
 	return object{
-		svg:              svg,
-		name:             name,
-		ref:              svg.nextReference(),
-		attrs:            make(map[string]string),
+		svg:           svg,
+		name:          name,
+		ref:           svg.nextReference(),
+		attrs:         make(map[string]string),
 		paintable:     makePaintable(),
 		transformable: makeTransformable(),
 	}

--- a/svg/paint.go
+++ b/svg/paint.go
@@ -5,62 +5,62 @@ import (
 	"github.com/jordan-bonecutter/purplecrayon/core"
 )
 
-type svgPaintable struct {
+type paintable struct {
 	attrs map[string]string
 }
 
-func makeSvgPaintable() svgPaintable {
-	return svgPaintable{
+func makePaintable() paintable {
+	return paintable{
 		attrs: make(map[string]string),
 	}
 }
 
-func (s svgPaintable) compile() []string {
-	ret := make([]string, len(s.attrs))
+func (p paintable) compile() []string {
+	ret := make([]string, len(p.attrs))
 	idx := 0
-	sortedMapIter(s.attrs, func(k, v string) {
+	sortedMapIter(p.attrs, func(k, v string) {
 		ret[idx] = fmt.Sprintf(`%s="%s"`, k, v)
 		idx++
 	})
 	return ret
 }
 
-func (s svgPaintable) FillTransparent() {
-	s.attrs["fill"] = "none"
+func (p paintable) FillTransparent() {
+	p.attrs["fill"] = "none"
 }
 
-func (s svgPaintable) FillRGB(color core.RGB) {
-	s.attrs["fill"] = svgRGB(color)
+func (p paintable) FillRGB(color core.RGB) {
+	p.attrs["fill"] = svgRGB(color)
 }
 
-func (s svgPaintable) FillRGBA(color core.RGBA) {
-	s.attrs["fill"] = svgRGBA(color)
+func (p paintable) FillRGBA(color core.RGBA) {
+	p.attrs["fill"] = svgRGBA(color)
 }
 
-func (s svgPaintable) Fill(ref core.Reference) {
-	s.attrs["fill"] = svgRef(ref)
+func (p paintable) Fill(ref core.Reference) {
+	p.attrs["fill"] = svgRef(ref)
 }
 
-func (s svgPaintable) StrokeWidth(w float64) {
-	s.attrs["stroke-width"] = fmt.Sprintf("%f", w)
+func (p paintable) StrokeWidth(w float64) {
+	p.attrs["stroke-width"] = fmt.Sprintf("%f", w)
 }
 
-func (s svgPaintable) StrokeRGB(color core.RGB) {
-	s.attrs["stroke"] = svgRGB(color)
+func (p paintable) StrokeRGB(color core.RGB) {
+	p.attrs["stroke"] = svgRGB(color)
 }
 
-func (s svgPaintable) StrokeRGBA(color core.RGBA) {
-	s.attrs["stroke"] = svgRGBA(color)
+func (p paintable) StrokeRGBA(color core.RGBA) {
+	p.attrs["stroke"] = svgRGBA(color)
 }
 
-func (s svgPaintable) StrokeTransparent() {
-	s.attrs["stroke"] = "none"
+func (p paintable) StrokeTransparent() {
+	p.attrs["stroke"] = "none"
 }
 
-func (s svgPaintable) Stroke(ref core.Reference) {
-	s.attrs["stroke"] = svgRef(ref)
+func (p paintable) Stroke(ref core.Reference) {
+	p.attrs["stroke"] = svgRef(ref)
 }
 
-func (s svgPaintable) CompositeMask(ref core.Reference) {
-	s.attrs["mask"] = svgRef(ref)
+func (p paintable) CompositeMask(ref core.Reference) {
+	p.attrs["mask"] = svgRef(ref)
 }

--- a/svg/rect.go
+++ b/svg/rect.go
@@ -5,23 +5,23 @@ import (
 	"github.com/jordan-bonecutter/purplecrayon/core"
 )
 
-type svgRect struct {
-	svgObject
+type rect struct {
+	object
 }
 
-func makeSvgRect(svg *svg) svgRect {
-	return svgRect{makeSvgObject(svg, "rect")}
+func makeRect(svg *svg) rect {
+	return rect{makeObject(svg, "rect")}
 }
 
-func (s svgRect) TopLeft(p core.Point) {
-	s.Set("x", fmt.Sprintf("%f", p.X))
-	s.Set("y", fmt.Sprintf("%f", p.Y))
+func (r rect) TopLeft(p core.Point) {
+	r.Set("x", fmt.Sprintf("%f", p.X))
+	r.Set("y", fmt.Sprintf("%f", p.Y))
 }
 
-func (s svgRect) Width(w float64) {
-	s.Set("width", fmt.Sprintf("%f", w))
+func (r rect) Width(w float64) {
+	r.Set("width", fmt.Sprintf("%f", w))
 }
 
-func (s svgRect) Height(h float64) {
-	s.Set("height", fmt.Sprintf("%f", h))
+func (r rect) Height(h float64) {
+	r.Set("height", fmt.Sprintf("%f", h))
 }

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -25,7 +25,7 @@ type canvas struct {
 	svg    *svg
 	width  float64
 	height float64
-	svgObject
+	object
 }
 
 func (svg *svg) nextReference() core.Reference {
@@ -33,10 +33,6 @@ func (svg *svg) nextReference() core.Reference {
 		svg.objectCounter++
 	}()
 	return core.Reference(fmt.Sprintf("pcobj-%d", svg.objectCounter))
-}
-
-func topLevelClose() core.Reference {
-	return ""
 }
 
 func (s *svg) WriteString(str string) {
@@ -53,7 +49,7 @@ func NewSVGCanvas(width, height float64, writer io.Writer) (pcCanvas pc.Canvas) 
 		svg:       root,
 		width:     width,
 		height:    height,
-		svgObject: makeSvgObject(root, "svg"),
+		object: makeObject(root, "svg"),
 	}
 
 	canv.Set("width", fmt.Sprintf("%f", width))
@@ -79,22 +75,22 @@ func (c canvas) Close() core.Reference {
 }
 
 func (c canvas) Rect() pc.Rect {
-	r := makeSvgRect(c.svg)
+	r := makeRect(c.svg)
 	return &r
 }
 
 func (c canvas) Circle() pc.Circle {
-	r := makeSvgCircle(c.svg)
+	r := makeCircle(c.svg)
 	return &r
 }
 
 func (c canvas) Cursor() pc.Cursor {
-	r := makeSvgCursor(c.svg)
+	r := makeCursor(c.svg)
 	return r
 }
 
 func (c canvas) LinearGradient() pc.LinearGradient {
-	return makeSvgLinearGradient(c.svg)
+	return makeLinearGradient(c.svg)
 }
 
 func (c canvas) Group() pc.Group {

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -75,18 +75,15 @@ func (c canvas) Close() core.Reference {
 }
 
 func (c canvas) Rect() pc.Rect {
-	r := makeRect(c.svg)
-	return &r
+	return makeRect(c.svg)
 }
 
 func (c canvas) Circle() pc.Circle {
-	r := makeCircle(c.svg)
-	return &r
+	return makeCircle(c.svg)
 }
 
 func (c canvas) Cursor() pc.Cursor {
-	r := makeCursor(c.svg)
-	return r
+	return makeCursor(c.svg)
 }
 
 func (c canvas) LinearGradient() pc.LinearGradient {

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -46,9 +46,9 @@ func NewSVGCanvas(width, height float64, writer io.Writer) (pcCanvas pc.Canvas) 
 		writer: writer,
 	}
 	canv := canvas{
-		svg:       root,
-		width:     width,
-		height:    height,
+		svg:    root,
+		width:  width,
+		height: height,
 		object: makeObject(root, "svg"),
 	}
 

--- a/svg/transform.go
+++ b/svg/transform.go
@@ -5,31 +5,31 @@ import (
 	"github.com/jordan-bonecutter/purplecrayon/core"
 )
 
-type svgTransformable struct {
+type transformable struct {
 	attrs map[string]string
 }
 
-func makeSvgTransformable() svgTransformable {
-	return svgTransformable{
+func makeTransformable() transformable {
+	return transformable{
 		attrs: make(map[string]string),
 	}
 }
 
-func (s svgTransformable) Translate(p core.Point) {
-	s.attrs["translate"] = fmt.Sprintf("translate(%f, %f)", p.X, p.Y)
+func (t transformable) Translate(p core.Point) {
+	t.attrs["translate"] = fmt.Sprintf("translate(%f, %f)", p.X, p.Y)
 }
 
-func (s svgTransformable) Scale(scale float64) {
-	s.attrs["scale"] = fmt.Sprintf("scale(%f)", scale)
+func (t transformable) Scale(scale float64) {
+	t.attrs["scale"] = fmt.Sprintf("scale(%f)", scale)
 }
 
-func (s svgTransformable) Rotate(degrees float64) {
-	s.attrs["rotate"] = fmt.Sprintf("rotate(%f)", degrees)
+func (t transformable) Rotate(degrees float64) {
+	t.attrs["rotate"] = fmt.Sprintf("rotate(%f)", degrees)
 }
 
-func (s svgTransformable) compile() []string {
+func (t transformable) compile() []string {
 	transform := ""
-	sortedMapIter(s.attrs, func(k, v string) {
+	sortedMapIter(t.attrs, func(k, v string) {
 		transform += " " + v
 	})
 	return []string{fmt.Sprintf(`transform="%s"`, transform)}

--- a/svg/tree.go
+++ b/svg/tree.go
@@ -7,21 +7,21 @@ import (
 
 type tree struct {
 	canvas
-	svgObject
+	object
 }
 
 func makeTree(svg *svg, canv canvas, name string) tree {
 	return tree{
 		canvas:    canv,
-		svgObject: makeSvgObject(svg, name),
+		object: makeObject(svg, name),
 	}
 }
 
 func (t tree) Open() pc.Canvas {
-	t.svgObject.Open()
+	t.object.Open()
 	return t
 }
 
 func (t tree) Close() core.Reference {
-	return t.svgObject.ClosingTag()
+	return t.object.ClosingTag()
 }

--- a/svg/tree.go
+++ b/svg/tree.go
@@ -12,7 +12,7 @@ type tree struct {
 
 func makeTree(svg *svg, canv canvas, name string) tree {
 	return tree{
-		canvas:    canv,
+		canvas: canv,
 		object: makeObject(svg, name),
 	}
 }


### PR DESCRIPTION
A lot of the structs began with `svg`, which is redundant because they're in the SVG package.